### PR TITLE
dumper: Add build targets for supported firmware versions

### DIFF
--- a/tools/dumper/Makefile
+++ b/tools/dumper/Makefile
@@ -21,6 +21,25 @@ OBJS    := $(patsubst $(SDIR)/%.c, $(ODIR)/%.o, $(CFILES)) \
 
 TARGET = $(shell basename $(CURDIR)).bin
 
+.PHONY: all
+all: 5.00
+
+.PHONY: 1.76
+1.76: CFLAGS += -DVERSION_176
+1.76: $(TARGET)
+
+.PHONY: 4.55
+4.55: CFLAGS += -DVERSION_455 
+4.55: $(TARGET)
+
+.PHONY: 5.00
+5.00: CFLAGS += -DVERSION_500
+5.00: $(TARGET)
+
+.PHONY: 5.05
+5.05: CFLAGS += -DVERSION_505 
+5.05: $(TARGET)
+
 $(TARGET): $(ODIR) $(OBJS)
 	$(CC) $(LIBPS4)/crt0.s $(ODIR)/*.o -o temp.t $(CFLAGS) $(LFLAGS) $(LIBS)
 	$(OBJCOPY) -O binary temp.t $(TARGET)
@@ -36,6 +55,5 @@ $(ODIR):
 	@mkdir $@
 
 .PHONY: clean
-
 clean:
 	rm -f $(TARGET) $(ODIR)/*.o

--- a/tools/dumper/README.md
+++ b/tools/dumper/README.md
@@ -2,12 +2,21 @@ Orbital Dumper
 ==============
 
 Dumper to dump/extract files required by Orbital from an actual PlayStation 4 console.
+The dumper currently supports PS4 FW ver 1.76, 4.55, 5.00, 5.05.
 
 ## Usage
 
 1. Connect your computer and PS4 to the same network.
 
-2. Setup [ps4-payload-sdk](https://github.com/xvortex/ps4-payload-sdk/) and build the payload with `make`.
+2. Setup [ps4-payload-sdk](https://github.com/xvortex/ps4-payload-sdk/). 
+
+3. Before building, change the IP address (`#define BLOBS_ADDR IP(192,168,2,1)`) found inside `source/blob.c` to the IP adress of the pc where the `server.py` will be running.
+
+4. Build the payload for your firmware version with `make`. Pick one of the following supported firmware versions: 1.76, 4.55, 5.00, 5.05. For example:
+
+    ```bash
+    make 5.00
+    ```
 
 3. Start the server with:
 
@@ -15,7 +24,11 @@ Dumper to dump/extract files required by Orbital from an actual PlayStation 4 co
     python server.py
     ```
 
-4. Enter your computer's IP address in the PlayStation 4 web browser and follow the instructions on screen.
+4. Enter your computer's IP address in the PlayStation 4 web browser and follow the instructions on screen. The exploit provided by `server.py` only works for firmware 5.00. If you are on a different firmware you need to run an exploit manually and send the dumper payload using netcat/socat:
+
+```bash
+socat -u FILE:dumper.bin TCP:"PS4 IP":9020
+```
 
 ## Development
 
@@ -29,10 +42,4 @@ Furthermore, the server will listen at port `9021` for incoming blobs, and optio
 
 ## Compiling Notes
 
-The dumper currently supports PS4 FW ver 1.76, 4.55, 5.00, 5.05.
-
-By default the build will default to ver 5.00, but in order to compile for a different FW, you must edit the include reference (`#include "ksdk_500.inc"`) found inside `source/ksdk.c` (2 includes to edit) and `source/ksdk.h` (1 include to edit) to match the desired FW.  
-
 If you want to add support for a new FW, use one of the `source/ksdk_XXX.inc` as template and update the required offset to match that of your FW.
-
-Before building, change the IP address (`#define BLOBS_ADDR IP(192,168,2,1)`) found inside `source/blob.c` to the IP adress of the pc where the `server.py` is running.

--- a/tools/dumper/README.md
+++ b/tools/dumper/README.md
@@ -18,13 +18,13 @@ The dumper currently supports PS4 FW ver 1.76, 4.55, 5.00, 5.05.
     make 5.00
     ```
 
-3. Start the server with:
+5. Start the server with:
 
     ```bash
     python server.py
     ```
 
-4. Enter your computer's IP address in the PlayStation 4 web browser and follow the instructions on screen. The exploit provided by `server.py` only works for firmware 5.00. If you are on a different firmware you need to run an exploit manually and send the dumper payload using netcat/socat:
+6. Enter your computer's IP address in the PlayStation 4 web browser and follow the instructions on screen. The exploit provided by `server.py` only works for firmware 5.00. If you are on a different firmware you need to run an exploit manually and send the dumper payload using netcat/socat:
 
 ```bash
 socat -u FILE:dumper.bin TCP:"PS4 IP":9020

--- a/tools/dumper/source/gpu_dumper.c
+++ b/tools/dumper/source/gpu_dumper.c
@@ -5,6 +5,8 @@
  * Based in previous tools and research by: fail0verflow, flatz.
  */
 
+#ifdef VERSION_500
+
 #include "gpu_dumper.h"
 #include "debug.h"
 
@@ -60,3 +62,5 @@ int gpu_dump_ih()
     hexdump("rb", &info.rb, 0x1000);
     return 0;
 }
+
+#endif

--- a/tools/dumper/source/ksdk.c
+++ b/tools/dumper/source/ksdk.c
@@ -9,17 +9,7 @@
     ret (*name) args
 #define KDATA(slide, name, type) \
     type* name
-
-#ifdef VERSION_176
-#include "ksdk_176.inc"
-#elif VERSION_455
-#include "ksdk_455.inc"
-#elif VERSION_500
-#include "ksdk_500.inc"
-#elif VERSION_505
-#include "ksdk_505.inc"
-#endif
-
+#include "ksdk.inc"
 #undef KFUNC
 #undef KDATA
 
@@ -41,17 +31,7 @@ void init_ksdk() {
     name = KSLIDE(slide)
 #define KDATA(slide, name, type) \
     name = KSLIDE(slide)
-
-#ifdef VERSION_176
-#include "ksdk_176.inc"
-#elif VERSION_455
-#include "ksdk_455.inc"
-#elif VERSION_500
-#include "ksdk_500.inc"
-#elif VERSION_505
-#include "ksdk_505.inc"
-#endif
-
+#include "ksdk.inc"
 #undef KFUNC
 #undef KDATA
 }

--- a/tools/dumper/source/ksdk.c
+++ b/tools/dumper/source/ksdk.c
@@ -9,7 +9,17 @@
     ret (*name) args
 #define KDATA(slide, name, type) \
     type* name
+
+#ifdef VERSION_176
+#include "ksdk_176.inc"
+#elif VERSION_455
+#include "ksdk_455.inc"
+#elif VERSION_500
 #include "ksdk_500.inc"
+#elif VERSION_505
+#include "ksdk_505.inc"
+#endif
+
 #undef KFUNC
 #undef KDATA
 
@@ -31,7 +41,17 @@ void init_ksdk() {
     name = KSLIDE(slide)
 #define KDATA(slide, name, type) \
     name = KSLIDE(slide)
+
+#ifdef VERSION_176
+#include "ksdk_176.inc"
+#elif VERSION_455
+#include "ksdk_455.inc"
+#elif VERSION_500
 #include "ksdk_500.inc"
+#elif VERSION_505
+#include "ksdk_505.inc"
+#endif
+
 #undef KFUNC
 #undef KDATA
 }

--- a/tools/dumper/source/ksdk.h
+++ b/tools/dumper/source/ksdk.h
@@ -25,17 +25,7 @@
     extern ret (*name) args
 #define KDATA(slide, name, type) \
     extern type* name
-
-#ifdef VERSION_176
-#include "ksdk_176.inc"
-#elif VERSION_455
-#include "ksdk_455.inc"
-#elif VERSION_500
-#include "ksdk_500.inc"
-#elif VERSION_505
-#include "ksdk_505.inc"
-#endif
-
+#include "ksdk.inc"
 #undef KFUNC
 #undef KDATA
 

--- a/tools/dumper/source/ksdk.h
+++ b/tools/dumper/source/ksdk.h
@@ -25,7 +25,17 @@
     extern ret (*name) args
 #define KDATA(slide, name, type) \
     extern type* name
+
+#ifdef VERSION_176
+#include "ksdk_176.inc"
+#elif VERSION_455
+#include "ksdk_455.inc"
+#elif VERSION_500
 #include "ksdk_500.inc"
+#elif VERSION_505
+#include "ksdk_505.inc"
+#endif
+
 #undef KFUNC
 #undef KDATA
 

--- a/tools/dumper/source/ksdk.inc
+++ b/tools/dumper/source/ksdk.inc
@@ -1,0 +1,11 @@
+#ifdef VERSION_176
+    #include "ksdk_176.inc"
+#elif VERSION_455
+#   include "ksdk_455.inc"
+#elif VERSION_500
+    #include "ksdk_500.inc"
+#elif VERSION_505
+    #include "ksdk_505.inc"
+#else
+    #error "Target firmware not yet supported."
+#endif

--- a/tools/dumper/source/main.c
+++ b/tools/dumper/source/main.c
@@ -64,10 +64,12 @@ void kpatch_enablemapself(struct thread *td)
     uint8_t* kernel_base = &((uint8_t*)read_msr(0xC0000082))[-0x1C0];
     uint8_t* map_self_patch1 = &kernel_base[0x117B0];
     uint8_t* map_self_patch2 = &kernel_base[0x117C0];
-#ifdef VERSION_505
-    uint8_t* map_self_patch3 = &kernel_base[0x13F03F]; //5.05
-#else
+#ifdef VERSION_500
     uint8_t* map_self_patch3 = &kernel_base[0x13EF2F];
+#elif VERSION_505
+    uint8_t* map_self_patch3 = &kernel_base[0x13F03F];
+#else
+    #error "Target firmware not yet supported."
 #endif
 
     // sceSblACMgrIsAllowedToMmapSelf result

--- a/tools/dumper/source/main.c
+++ b/tools/dumper/source/main.c
@@ -64,8 +64,11 @@ void kpatch_enablemapself(struct thread *td)
     uint8_t* kernel_base = &((uint8_t*)read_msr(0xC0000082))[-0x1C0];
     uint8_t* map_self_patch1 = &kernel_base[0x117B0];
     uint8_t* map_self_patch2 = &kernel_base[0x117C0];
-    /* map_self_patch3 = &kernel_base[0x13F03F]; (5.05) */
+#ifdef VERSION_505
+    uint8_t* map_self_patch3 = &kernel_base[0x13F03F]; //5.05
+#else
     uint8_t* map_self_patch3 = &kernel_base[0x13EF2F];
+#endif
 
     // sceSblACMgrIsAllowedToMmapSelf result
     kmem = (uint8_t*)map_self_patch1;
@@ -217,8 +220,8 @@ int _main(struct thread *td)
     syscall(11, kpatch_enablemapself);
 
     /* Dump data */
-    //traverse_dir("/", true, decrypt_self_to_blobs);
-    //traverse_dir("/", true, decrypt_self_to_elf);
+    traverse_dir("/", true, decrypt_self_to_blobs);
+    traverse_dir("/", true, decrypt_self_to_elf);
     //gpu_dump_ih();
 
     /* Return back to browser */


### PR DESCRIPTION
This removes the requirement to include the correct includes manually.
The gpu dumper is only build for firmware 5.00 as we are missing the offsets for the other firmware versions.
Also update the README to reflect the changes and add more information for getting the payload to run on other firmware versions than 5.00.