### PR TITLE
Fix the build_bios function in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ options:
 function build_bios() {
     cd "${path_bios}" || exit 1
     make "-j$(nproc)"
-    mv out/bios.bin "../${path_bin}/ubios.bin"
+    mv out/bios.bin "${path_bin}/ubios.bin"
 }
 
 function build_grub() {


### PR DESCRIPTION
Fix the destination path of the ubios.bin in the build_bios function.