### PR TITLE
Add openssl-devel to the dependencies

### DIFF
--- a/docs/manual-windows.md
+++ b/docs/manual-windows.md
@@ -12,7 +12,7 @@
     pacman -S mingw-w64-x86_64-glib2 mingw-w64-x86_64-gtk3
     pacman -S mingw-w64-x86_64-vulkan mingw-w64-x86_64-SDL2
     pacman -S mingw-w64-x86_64-glslang mingw-w64-x86_64-libzip
-    pacman -S mingw-w64-x86_64-libusb
+    pacman -S mingw-w64-x86_64-libusb openssl-devel
     ```
 
 3. Run the following commands to setup a proper environment:


### PR DESCRIPTION
This shouldn't be needed, but sometimes pacman doesn't install this.