### PR TITLE
Add script to rearrange dump files into directory tree

### DIFF
--- a/tools/dumper/arrange_dump.py
+++ b/tools/dumper/arrange_dump.py
@@ -1,0 +1,20 @@
+import os
+import re
+
+dirstats = {}
+lvls = 3
+namepattern = re.compile(r'^[A-F0-9]{32}.bin$')
+replacepattern = re.compile(r'[A-F0-9]{2}')
+for name in os.listdir('dump'):
+    name = 'dump/' + name
+    if not os.path.isfile(name) or not namepattern.match(os.path.basename(name)):
+        continue
+    newname = replacepattern.sub('\g<0>/', name, lvls)
+    dirname = os.path.dirname(newname)
+    if dirname not in dirstats:
+        dirstats[dirname] = 0
+    dirstats[dirname] += 1
+    os.makedirs(dirname, exist_ok=True)
+    os.rename(name, newname)
+
+print("Maximum number of files in folder:", max(dirstats.values()))


### PR DESCRIPTION
This PR adds script to rearrange dump files to be stored in several "levels" of folders so that they are more manageable.