### PR TITLE
Update manual-linux.md

### DIFF
--- a/docs/manual-linux.md
+++ b/docs/manual-linux.md
@@ -34,8 +34,7 @@ sudo pacman -S \
 
 ## Dependencies for orbital-grub
 curl -s https://aur.archlinux.org/cgit/aur.git/snapshot/dh-autoreconf.tar.gz | tar xvz \
-    && cd dh-autoreconf && makepkg -Acs && sudo pacman -U dh-autoreconf_19.tar.xz \
-    && cd .. && rm -rf dh-autoreconf
+    && cd dh-autoreconf && makepkg -Acsi && cd .. && rm -rf dh-autoreconf
 
 sudo pacman -S \
     bison flex


### PR DESCRIPTION
Instead of using pacman directly as a command to install the package, we can make makepkg do that for us, thereby shortening the command.