### PR TITLE
env/run: add cdrom for bdvd and disable clflush

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -9,6 +9,7 @@ cd "${0%/*}"
     -kernel ./boot.img \
     -drive if=none,id=hdd,file=hdd.qcow2 \
     -drive if=none,id=usb,file=usb/usb-pup-500rec.qcow2,read-only=on \
+    -drive if=ide,index=0,media=cdrom \
     -device usb-storage,drive=hdd,bus=axhci1.0,port=1 \
     -device usb-storage,drive=usb,bus=axhci2.0 \
     -monitor stdio -smp 8 -display orbital \

--- a/resources/boot/grub/env-common.cfg
+++ b/resources/boot/grub/env-common.cfg
@@ -1,5 +1,6 @@
 ### Environment
 hw.memtest.tests=0
+hw.clflush_disable=1
 #hw.acpi.verbose=1
 #hw.usb.xhci.debug=1
 #kern.init_safe_mode=0


### PR DESCRIPTION
More stuff to get to initialize screen, cdrom is needed for bdvd stuff,
the clflush, while for some reason *doesnt* cause a vmexit on intel, does on amd, but either way it shouldnt matter for a vm, unless im missing a reason it should stay