### PR TITLE
Update manual-linux.md

### DIFF
--- a/docs/manual-linux.md
+++ b/docs/manual-linux.md
@@ -12,11 +12,11 @@ sudo apt install -qq \
     git python
 
 ## Dependencies for orbital-grub
-sudo apt -qq install \
+sudo apt install -qq \
     dh-autoreconf bison flex
 
 ## Dependencies for orbital-qemu
-sudo apt -qq install \
+sudo apt install -qq \
     zlib1g-dev libglib2.0-dev libfdt-dev libpixman-1-dev libsdl2-dev \
     libvulkan-dev libzip-dev libusb-1.0-0-dev glslang-dev
 

--- a/docs/manual-linux.md
+++ b/docs/manual-linux.md
@@ -8,7 +8,7 @@
 ####  Ubuntu
 ```bash
 ## Common dependencies
-sudo apt -qq install \
+sudo apt install -qq \
     git python
 
 ## Dependencies for orbital-grub


### PR DESCRIPTION
The `-qq` flag needs to explicitly be specified after the install command in order not to print the usage on Ubuntu 18.04